### PR TITLE
[Feature] PhoneAsItem Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ of NPWD and QBCore installed**
 2. Run the `patch.sql` to patch the database for NPWD
 3. Add `ensure qb-npwd` to your `server.cfg` (Start this resource after `QBCore` and `NPWD` have been started)
 
+## Enabling PhoneAsItem Support
+If you wish to require a player to have a phone item in there inventory, you must follow the steps below.
+
+1. Navigate to the `config.json` in `NPWD` and change the following settings under `PhoneAsItem`:
+	a. `enabled` to `true`
+	b. `exportResource` to `qb-npwd`
+	c. `exportResource` to `HasPhone`
+2. Navigate to the `config.lua` in `qb-npwd` and verify all the items you want to work as a phone are listed.
+
+## Other Features
+1. Double clicking any phone items in the inventory will open the phone. If you want to be able to drag and drop phone items over the Use button in the inventory, you must navigate to `qb-core/shared/items.lua`, find your phone item, and change `usable` to `true` and `shouldClose` to `true`.

--- a/client.lua
+++ b/client.lua
@@ -2,7 +2,7 @@ local QBCore = exports['qb-core']:GetCoreObject()
 
 local function HasPhone()
     local _hasPhone = nil
-    QBCore.Functions.TriggerCallback('qb-npwd:HasPhone', function(hasPhone) _hasPhone = hasPhone end)
+    QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasItem) _hasPhone = hasItem end, Config.PhoneList)
     while _hasPhone == nil do Wait(100) end
     return _hasPhone
 end

--- a/client.lua
+++ b/client.lua
@@ -1,7 +1,45 @@
 local QBCore = exports['qb-core']:GetCoreObject()
+local hasPhone = false
+
+local function DoPhoneCheck(PlayerItems)
+    hasPhone = false
+    
+    if PlayerItems then
+        for _,item in pairs(PlayerItems) do
+            if Config.PhoneList[item.name] then
+                hasPhone = true
+                break;
+            end
+        end
+    end
+
+    exports['npwd']:setPhoneDisabled(not hasPhone)
+end
 
 local function HasPhone()
-    return QBCore.Functions.HasItem(Config.PhoneList)
+    return hasPhone
 end
   
 exports("HasPhone", HasPhone)
+
+-- Handles state right when the player selects their character and location.
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    DoPhoneCheck(QBCore.Functions.GetPlayerData().items)
+end)
+
+-- Resets state on logout, in case of character change.
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
+    DoPhoneCheck(nil)
+end)
+
+-- Handles state when PlayerData is changed. We're just looking for inventory updates.
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(PlayerData)
+    DoPhoneCheck(PlayerData.items)
+end)
+
+-- Handles state if resource is restarted live.
+AddEventHandler('onResourceStart', function(resource)
+    if GetCurrentResourceName() == resource then
+        DoPhoneCheck(QBCore.Functions.GetPlayerData().items)
+    end
+end)

--- a/client.lua
+++ b/client.lua
@@ -1,9 +1,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
 local function HasPhone()
-    local p = promise.new()
-    QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasItem) p:resolve(hasItem) end, Config.PhoneList)
-    return Citizen.Await(p)
+    return QBCore.Functions.HasItem(Config.PhoneList)
 end
   
 exports("HasPhone", HasPhone)

--- a/client.lua
+++ b/client.lua
@@ -1,10 +1,9 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
 local function HasPhone()
-    local _hasPhone = nil
-    QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasItem) _hasPhone = hasItem end, Config.PhoneList)
-    while _hasPhone == nil do Wait(100) end
-    return _hasPhone
+    local p = promise.new()
+    QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasItem) p:resolve(hasItem) end, Config.PhoneList)
+    return Citizen.Await(p)
 end
   
 exports("HasPhone", HasPhone)

--- a/client.lua
+++ b/client.lua
@@ -1,0 +1,10 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local function HasPhone()
+    local _hasPhone = nil
+    QBCore.Functions.TriggerCallback('qb-npwd:HasPhone', function(hasPhone) _hasPhone = hasPhone end)
+    while _hasPhone == nil do Wait(100) end
+    return _hasPhone
+end
+  
+exports("HasPhone", HasPhone)

--- a/client.lua
+++ b/client.lua
@@ -39,7 +39,12 @@ end)
 
 -- Handles state if resource is restarted live.
 AddEventHandler('onResourceStart', function(resource)
-    if GetCurrentResourceName() == resource then
+    if GetCurrentResourceName() == resource and GetResourceState('npwd') == 'started' then
         DoPhoneCheck(QBCore.Functions.GetPlayerData().items)
     end
+end)
+
+-- Allows use of phone as an item.
+RegisterNetEvent('qb-npwd:client:setPhoneVisible', function(isPhoneVisible)
+    exports['npwd']:setPhoneVisible(isPhoneVisible)
 end)

--- a/client.lua
+++ b/client.lua
@@ -3,13 +3,13 @@ local hasPhone = false
 
 local function DoPhoneCheck(PlayerItems)
     hasPhone = false
-    
-    if PlayerItems then
-        for _,item in pairs(PlayerItems) do
-            if Config.PhoneList[item.name] then
-                hasPhone = true
-                break;
-            end
+
+    if not PlayerItems then return end
+
+    for _,item in pairs(PlayerItems) do
+        if Config.PhoneList[item.name] then
+            hasPhone = true
+            break;
         end
     end
 

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,6 @@
 Config = {}
 
+-- List the items you want to register as a phone here.
 Config.PhoneList = {
-    ['phone'] = 1,
+    ['phone'] = true,
 }

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,5 @@
+Config = {}
+
+Config.PhoneList = {
+    'phone'
+}

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 Config = {}
 
 Config.PhoneList = {
-    'phone'
+    ['phone'] = 1,
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,10 @@ description 'A simple bridge resource for QB Compatibility for NPWD'
 
 lua54 'yes'
 
+client_script 'client.lua'
+
 server_scripts {
+  'config.lua',
   'sv_utils.lua',
   'server.lua'
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,12 +4,11 @@ description 'A simple bridge resource for QB Compatibility for NPWD'
 
 lua54 'yes'
 
-client_scripts {
-  'config.lua',
-  'client.lua',
-}
+client_script 'client.lua'
 
 server_scripts {
   'sv_utils.lua',
   'server.lua'
 }
+
+shared_script 'config.lua'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,10 +4,12 @@ description 'A simple bridge resource for QB Compatibility for NPWD'
 
 lua54 'yes'
 
-client_script 'client.lua'
+client_scripts {
+  'config.lua',
+  'client.lua',
+}
 
 server_scripts {
-  'config.lua',
   'sv_utils.lua',
   'server.lua'
 }

--- a/server.lua
+++ b/server.lua
@@ -1,5 +1,18 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
+QBCore.Functions.CreateCallback('qb-npwd:HasPhone', function(source, cb)
+  local Player = QBCore.Functions.GetPlayer(source)
+
+  local hasPhone = false
+  for _,phone in ipairs(Config.PhoneList) do
+    if Player.Functions.GetItemByName(phone) then 
+      hasPhone = true 
+      break;
+    end
+  end
+  cb(hasPhone)
+end)
+
 AddEventHandler('QBCore:Server:PlayerLoaded', function(qbPlayer)
   local playerIdent = qbPlayer.PlayerData.citizenid
   local phoneNumber = tostring(qbPlayer.PlayerData.charinfo.phone)

--- a/server.lua
+++ b/server.lua
@@ -40,3 +40,7 @@ AddEventHandler('onServerResourceStart', function(resName)
     })
   end
 end)
+
+QBCore.Functions.CreateUseableItem(getTableKeys(Config.PhoneList), function(source, item)
+  TriggerClientEvent('qb-npwd:client:setPhoneVisible', source, true)
+end)

--- a/server.lua
+++ b/server.lua
@@ -1,18 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
-QBCore.Functions.CreateCallback('qb-npwd:HasPhone', function(source, cb)
-  local Player = QBCore.Functions.GetPlayer(source)
-
-  local hasPhone = false
-  for _,phone in ipairs(Config.PhoneList) do
-    if Player.Functions.GetItemByName(phone) then 
-      hasPhone = true 
-      break;
-    end
-  end
-  cb(hasPhone)
-end)
-
 AddEventHandler('QBCore:Server:PlayerLoaded', function(qbPlayer)
   local playerIdent = qbPlayer.PlayerData.citizenid
   local phoneNumber = tostring(qbPlayer.PlayerData.charinfo.phone)

--- a/sv_utils.lua
+++ b/sv_utils.lua
@@ -30,3 +30,11 @@ function printTable(tbl, indent)
     end
   end
 end
+
+function getTableKeys(tbl)
+  local keys = {}
+  for k,_ in pairs(tbl) do
+    keys[#keys+1] = k
+  end
+  return keys
+end


### PR DESCRIPTION
- Added support for PhoneAsItem export from NPWD
- Added config with array of acceptable phone items in case a server has multiple phone types

Users will still need to enable this feature in the NPWD config.json.
- Set "enabled" to true
- Set "exportResource" to "qb-npwd"
- Set "exportFunction" to "HasPhone"